### PR TITLE
Refresh Token Support for AUTH_MODE="api"

### DIFF
--- a/src/Laravel/Controllers/CallbackApiController.php
+++ b/src/Laravel/Controllers/CallbackApiController.php
@@ -41,7 +41,8 @@ class CallbackApiController extends BaseController
         'httponly' => true,
         'samesite' => 'None'
       );
-      return response()->json($body, Response::HTTP_OK)->cookie('saasus_refresh_token', $body['refresh_token'], $arr_cookie_options);
+      setcookie('saasus_refresh_token', $body['refresh_token'], $arr_cookie_options);
+      return response()->json($body, Response::HTTP_OK);
     } catch (GetAuthCredentialsNotFoundException | GetAuthCredentialsInternalServerErrorException $e) {
       if (get_class($e) == 'GetAuthCredentialsNotFoundException') {
         Log::info('Type: Not Found, Message: ' . $e->getError());

--- a/src/Laravel/Controllers/CallbackApiController.php
+++ b/src/Laravel/Controllers/CallbackApiController.php
@@ -36,7 +36,7 @@ class CallbackApiController extends BaseController
       }
       $arr_cookie_options = array(
         'expires' => time() + 60 * 60 * 24 * 30,
-        'path' => '/api/new-tokens',
+        'path' => '/api/token/refresh',
         'secure' => true,
         'httponly' => true,
         'samesite' => 'None'

--- a/src/Laravel/Controllers/CallbackController.php
+++ b/src/Laravel/Controllers/CallbackController.php
@@ -23,7 +23,6 @@ class CallbackController extends BaseController
             return redirect(getenv('SAASUS_LOGIN_URL'));
         }
         $idToken = '';
-        $refreshToken = '';
         $client = new ApiClient;
         $authApiClient = $client->getAuthClient();
         try {
@@ -31,7 +30,6 @@ class CallbackController extends BaseController
                 'code' => $request->code, 'auth-flow' => 'tempCodeAuth',
             ]);
             $idToken = $res->getIdToken();
-            $refreshToken = $res->getRefreshToken();
         } catch (GetAuthCredentialsNotFoundException | GetAuthCredentialsInternalServerErrorException $e) {
             if (get_class($e) == 'GetAuthCredentialsNotFoundException') {
                 Log::info('Type: Not Found, Message: ' . $e->getError());
@@ -40,28 +38,18 @@ class CallbackController extends BaseController
             Log::info('Type: Internal Server Error, Message: ' . $e->getError());
             return redirect(getenv('SAASUS_LOGIN_URL'));
         }
-        $idTokenCookieOptions = array(
+        $arr_cookie_options = array(
+            //            'expires' => time() + 60 * 60 * 24 * 30,
             'path' => '/',
-            'secure' => true,
-            'httponly' => true,
-            'samesite' => 'Strict'
+            //            'domain' => '.example.com', // leading dot for compatibility or use subdomain
+            'secure' => false,     // or false
+            'httponly' => true,    // or false
+            'samesite' => 'Strict' // None || Lax  || Strict
         );
         setcookie(
             'SaaSus_idToken',
             $idToken,
-            $idTokenCookieOptions
-        );
-        $refreshTokenCookieOptions = array(
-            'expires' => time() + 60 * 60 * 24 * 30,
-            'path' => '/token/refresh',
-            'secure' => true,
-            'httponly' => true,
-            'samesite' => 'Strict',
-        );
-        setcookie(
-            'SaaSus_refreshToken',
-            $refreshToken,
-            $refreshTokenCookieOptions,
+            $arr_cookie_options
         );
 
         return response()->view('saasus_default_callback', ['idToken' => $idToken]);

--- a/src/Laravel/Controllers/CallbackController.php
+++ b/src/Laravel/Controllers/CallbackController.php
@@ -53,7 +53,7 @@ class CallbackController extends BaseController
         );
         $refreshTokenCookieOptions = array(
             'expires' => time() + 60 * 60 * 24 * 30,
-            'path' => '/new-tokens',
+            'path' => '/token/refresh',
             'secure' => true,
             'httponly' => true,
             'samesite' => 'Strict',


### PR DESCRIPTION
- Set cookie in CallbackApiConrtoller response
- Create TokenRefreshApiController which gets new user credentials (id_token and access_token) by using refresh token stored in cookie