### PR TITLE
Fix Error Handling in Functions with API Requests

### DIFF
--- a/src/Laravel/Controllers/CallbackApiController.php
+++ b/src/Laravel/Controllers/CallbackApiController.php
@@ -12,8 +12,6 @@ use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 use AntiPatternInc\Saasus\Api\Client as ApiClient;
-use AntiPatternInc\Saasus\Sdk\Auth\Exception\GetAuthCredentialsNotFoundException;
-use AntiPatternInc\Saasus\Sdk\Auth\Exception\GetAuthCredentialsInternalServerErrorException;
 use Http\Client\Exception\HttpException;
 
 class CallbackApiController extends BaseController

--- a/src/Laravel/Controllers/CallbackApiController.php
+++ b/src/Laravel/Controllers/CallbackApiController.php
@@ -41,7 +41,8 @@ class CallbackApiController extends BaseController
         'httponly' => true,
         'samesite' => 'None'
       );
-      return response()->json($body, Response::HTTP_OK)->cookie('saasus_refresh_token', $body['refresh_token'], $arr_cookie_options);
+      setcookie('saasus_refresh_token', $body['refresh_token'], $arr_cookie_options);
+      return response()->json($body, Response::HTTP_OK);
     } catch (GetAuthCredentialsNotFoundException | GetAuthCredentialsInternalServerErrorException $e) {
       if (get_class($e) == 'GetAuthCredentialsNotFoundException') {
         Log::info('Type: Not Found, Message: ' . $e->getError());

--- a/src/Laravel/Controllers/CallbackApiController.php
+++ b/src/Laravel/Controllers/CallbackApiController.php
@@ -54,6 +54,7 @@ class CallbackApiController extends BaseController
         Log::info('Type: ' . $type . ', Message: ' . $message);
         return response()->json(['type' => $type, 'message' => $message], Response::HTTP_INTERNAL_SERVER_ERROR);
       }
+      Log::info('Uncaught error: ' . $e);
       return response()->json('Uncaught error', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/Laravel/Controllers/CallbackApiController.php
+++ b/src/Laravel/Controllers/CallbackApiController.php
@@ -47,14 +47,16 @@ class CallbackApiController extends BaseController
     } catch (\Exception $e) {
       if ($e instanceof HttpException) {
         $statusCode = $e->getResponse()->getStatusCode();
+        $type = json_decode($e->getResponse()->getBody(), true)["type"];
+        $message = json_decode($e->getResponse()->getBody(), true)["message"];
         if ($statusCode == Response::HTTP_NOT_FOUND) {
-          Log::info('Type: Not Found, Message: ' . $e->getResponse());
-          return response()->json("Credentials Not Found", Response::HTTP_NOT_FOUND);
+          Log::info('Type: ' . $type . ', Message: ' . $message);
+          return response()->json(['type' => $type, 'message' => $message], Response::HTTP_NOT_FOUND);
         }
-        Log::info('Type: Internal Server Error, Message: ' . $e->getResponse());
-        return response()->json('Internal Server Error', Response::HTTP_INTERNAL_SERVER_ERROR);
+        Log::info('Type: ' . $type . ', Message: ' . $message);
+        return response()->json(['type' => $type, 'message' => $message], Response::HTTP_INTERNAL_SERVER_ERROR);
       }
-      return response()->json('Internal Server Error', Response::HTTP_INTERNAL_SERVER_ERROR);
+      return response()->json('Uncaught error', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/Laravel/Controllers/CallbackApiController.php
+++ b/src/Laravel/Controllers/CallbackApiController.php
@@ -36,7 +36,7 @@ class CallbackApiController extends BaseController
       }
       $arr_cookie_options = array(
         'expires' => time() + 60 * 60 * 24 * 30,
-        'path' => '/api/new-tokens',
+        'path' => '/api/token/refresh',
         'secure' => true,
         'httponly' => true,
         'samesite' => 'None'

--- a/src/Laravel/Controllers/CallbackController.php
+++ b/src/Laravel/Controllers/CallbackController.php
@@ -33,11 +33,13 @@ class CallbackController extends BaseController
         } catch (\Exception $e) {
             if ($e instanceof HttpException) {
                 $statusCode = $e->getResponse()->getStatusCode();
+                $type = json_decode($e->getResponse()->getBody(), true)["type"];
+                $message = json_decode($e->getResponse()->getBody(), true)["message"];
                 if ($statusCode == Response::HTTP_NOT_FOUND) {
-                    Log::info('Type: Not Found, Message: ' . $e->getResponse());
+                    Log::info('Type: ' . $type . ', Message: ' . $message);
                     return redirect(getenv('SAASUS_LOGIN_URL'));
                 }
-                Log::info('Type: Internal Server Error, Message: ' . $e->getResponse());
+                Log::info('Type: ' . $type . ', Message: ' . $message);
                 return redirect(getenv('SAASUS_LOGIN_URL'));
             }
             return redirect(getenv('SAASUS_LOGIN_URL'));

--- a/src/Laravel/Controllers/CallbackController.php
+++ b/src/Laravel/Controllers/CallbackController.php
@@ -42,6 +42,7 @@ class CallbackController extends BaseController
                 Log::info('Type: ' . $type . ', Message: ' . $message);
                 return redirect(getenv('SAASUS_LOGIN_URL'));
             }
+            Log::info('Uncaught error: ' . $e);
             return redirect(getenv('SAASUS_LOGIN_URL'));
         }
         $arr_cookie_options = array(

--- a/src/Laravel/Controllers/CallbackController.php
+++ b/src/Laravel/Controllers/CallbackController.php
@@ -23,7 +23,6 @@ class CallbackController extends BaseController
             return redirect(getenv('SAASUS_LOGIN_URL'));
         }
         $idToken = '';
-        $refreshToken = '';
         $client = new ApiClient;
         $authApiClient = $client->getAuthClient();
         try {
@@ -31,7 +30,6 @@ class CallbackController extends BaseController
                 'code' => $request->code, 'auth-flow' => 'tempCodeAuth',
             ]);
             $idToken = $res->getIdToken();
-            $refreshToken = $res->getRefreshToken();
         } catch (GetAuthCredentialsNotFoundException | GetAuthCredentialsInternalServerErrorException $e) {
             if (get_class($e) == 'GetAuthCredentialsNotFoundException') {
                 Log::info('Type: Not Found, Message: ' . $e->getError());
@@ -40,28 +38,18 @@ class CallbackController extends BaseController
             Log::info('Type: Internal Server Error, Message: ' . $e->getError());
             return redirect(getenv('SAASUS_LOGIN_URL'));
         }
-        $idTokenCookieOptions = array(
+        $arr_cookie_options = array(
+            //            'expires' => time() + 60 * 60 * 24 * 30,
             'path' => '/',
-            'secure' => true,
-            'httponly' => true,
-            'samesite' => 'Strict'
+            //            'domain' => '.example.com', // leading dot for compatibility or use subdomain
+            'secure' => false,     // or false
+            'httponly' => true,    // or false
+            'samesite' => 'Strict' // None || Lax  || Strict
         );
         setcookie(
             'SaaSus_idToken',
             $idToken,
-            $idTokenCookieOptions
-        );
-        $refreshTokenCookieOptions = array(
-            'expires' => time() + 60 * 60 * 24 * 30,
-            'path' => '/token/refresh',
-            'secure' => true,
-            'httponly' => true,
-            'samesite' => 'Strict',
-        );
-        setcookie(
-            'SaaSus_refreshToken',
-            $refreshToken,
-            $refreshTokenCookieOptions,
+            $arr_cookie_options
         );
 
         return response()->view('saasus_default_callback', ['idToken' => $idToken]);

--- a/src/Laravel/Controllers/CallbackController.php
+++ b/src/Laravel/Controllers/CallbackController.php
@@ -53,7 +53,7 @@ class CallbackController extends BaseController
         );
         $refreshTokenCookieOptions = array(
             'expires' => time() + 60 * 60 * 24 * 30,
-            'path' => '/new-tokens',
+            'path' => '/token/refresh',
             'secure' => true,
             'httponly' => true,
             'samesite' => 'Strict',

--- a/src/Laravel/Controllers/TokenRefreshApiController.php
+++ b/src/Laravel/Controllers/TokenRefreshApiController.php
@@ -12,9 +12,8 @@ use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 use AntiPatternInc\Saasus\Api\Client as ApiClient;
-use AntiPatternInc\Saasus\Sdk\Auth\Exception\GetAuthCredentialsNotFoundException;
-use AntiPatternInc\Saasus\Sdk\Auth\Exception\GetAuthCredentialsInternalServerErrorException;
 use Error;
+use Http\Client\Exception\HttpException;
 
 class TokenRefreshApiController extends BaseController
 {
@@ -37,12 +36,17 @@ class TokenRefreshApiController extends BaseController
         throw new Error('failed to get new credentials');
       }
       return response()->json($body, Response::HTTP_OK);
-    } catch (GetAuthCredentialsNotFoundException | GetAuthCredentialsInternalServerErrorException $e) {
-      if (get_class($e) == 'GetAuthCredentialsNotFoundException') {
-        Log::info('Type: Not Found, Message: ' . $e->getError());
-        return response()->json('credentials not found', Response::HTTP_NOT_FOUND);
+    } catch (\Exception $e) {
+      if ($e instanceof HttpException) {
+        $statusCode = $e->getResponse()->getStatusCode();
+        if ($statusCode == Response::HTTP_NOT_FOUND) {
+          Log::info('Type: Not Found, Message: ' . $e->getResponse());
+          return response()->json("Credentials Not Found", Response::HTTP_NOT_FOUND);
+        }
+        Log::info('Type: Internal Server Error, Message: ' . $e->getResponse());
+        return response()->json('Internal Server Error', Response::HTTP_INTERNAL_SERVER_ERROR);
       }
-      return response()->json('internal server error', Response::HTTP_INTERNAL_SERVER_ERROR);
+      return response()->json('Internal Server Error', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/Laravel/Controllers/TokenRefreshApiController.php
+++ b/src/Laravel/Controllers/TokenRefreshApiController.php
@@ -48,6 +48,7 @@ class TokenRefreshApiController extends BaseController
         Log::info('Type: ' . $type . ', Message: ' . $message);
         return response()->json(['type' => $type, 'message' => $message], Response::HTTP_INTERNAL_SERVER_ERROR);
       }
+      Log::info('Uncaught error: ' . $e);
       return response()->json('Uncaught error', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
   }

--- a/src/Laravel/Controllers/TokenRefreshApiController.php
+++ b/src/Laravel/Controllers/TokenRefreshApiController.php
@@ -39,14 +39,16 @@ class TokenRefreshApiController extends BaseController
     } catch (\Exception $e) {
       if ($e instanceof HttpException) {
         $statusCode = $e->getResponse()->getStatusCode();
+        $type = json_decode($e->getResponse()->getBody(), true)["type"];
+        $message = json_decode($e->getResponse()->getBody(), true)["message"];
         if ($statusCode == Response::HTTP_NOT_FOUND) {
-          Log::info('Type: Not Found, Message: ' . $e->getResponse());
-          return response()->json("Credentials Not Found", Response::HTTP_NOT_FOUND);
+          Log::info('Type: ' . $type . ', Message: ' . $message);
+          return response()->json(['type' => $type, 'message' => $message], Response::HTTP_NOT_FOUND);
         }
-        Log::info('Type: Internal Server Error, Message: ' . $e->getResponse());
-        return response()->json('Internal Server Error', Response::HTTP_INTERNAL_SERVER_ERROR);
+        Log::info('Type: ' . $type . ', Message: ' . $message);
+        return response()->json(['type' => $type, 'message' => $message], Response::HTTP_INTERNAL_SERVER_ERROR);
       }
-      return response()->json('Internal Server Error', Response::HTTP_INTERNAL_SERVER_ERROR);
+      return response()->json('Uncaught error', Response::HTTP_INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/Laravel/Middleware/Auth.php
+++ b/src/Laravel/Middleware/Auth.php
@@ -57,6 +57,7 @@ class Auth
                 Log::info('Type: ' . $type . ', Message: ' . $message);
                 return response()->json(['type' => $type, 'message' => $message], Response::HTTP_INTERNAL_SERVER_ERROR);
             }
+            Log::info('Uncaught error: ' . $e);
             return response()->json('Uncaught error', Response::HTTP_INTERNAL_SERVER_ERROR);
         }
 

--- a/src/Laravel/Middleware/Auth.php
+++ b/src/Laravel/Middleware/Auth.php
@@ -44,16 +44,18 @@ class Auth
         } catch (\Exception $e) {
             if ($e instanceof HttpException) {
                 $statusCode = $e->getResponse()->getStatusCode();
+                $type = json_decode($e->getResponse()->getBody(), true)["type"];
+                $message = json_decode($e->getResponse()->getBody(), true)["message"];
                 if ($statusCode == Response::HTTP_UNAUTHORIZED) {
-                    Log::info('Type: Unauthorized, Message: ' . $e->getResponse());
+                    Log::info('Type: ' . $type . ', Message: ' . $message);
                     if (getenv('SAASUS_AUTH_MODE') == "api") {
-                        return response()->json('Invalid ID Token.', Response::HTTP_UNAUTHORIZED);
+                        return response()->json(['type' => $type, 'message' => $message], Response::HTTP_UNAUTHORIZED);
                     } else {
                         return redirect(getenv('SAASUS_LOGIN_URL'));
                     }
                 }
-                Log::info('Type: Intenal Server Error, Message: ' . $e->getResponse());
-                return response()->json('Unexpected response: ' . $e->getResponse(), Response::HTTP_INTERNAL_SERVER_ERROR);
+                Log::info('Type: ' . $type . ', Message: ' . $message);
+                return response()->json(['type' => $type, 'message' => $message], Response::HTTP_INTERNAL_SERVER_ERROR);
             }
             return response()->json('Uncaught error', Response::HTTP_INTERNAL_SERVER_ERROR);
         }


### PR DESCRIPTION
- Use `HttpException` to catch errors of API requests
- Return error responses with `type` and `message`