### PR TITLE
パッケージを公開するワークフローを追加する

### DIFF
--- a/.github/workflows/publish-packagist.yml
+++ b/.github/workflows/publish-packagist.yml
@@ -1,0 +1,25 @@
+name: Publish PHP Package to Packagist
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        php-version: ["8.2"]
+
+    steps:
+      - name: Notify Packagist
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_API_TOKEN: ${{ secrets.PACKAGIST_API_TOKEN }}
+        run: |
+          curl -XPOST -u "$PACKAGIST_USERNAME:$PACKAGIST_API_TOKEN" \
+          https://packagist.org/api/update-package?username=$PACKAGIST_USERNAME \
+          -d '{"repository":{"url":"https://github.com/saasus-platform/saasus-sdk-php"}}'

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,25 @@
   },
   "authors": [
     {
-      "name": "SaaSus Platform",
+      "name": "Anti-Pattern Inc.",
       "email": "saasus@anti-pattern.co.jp"
     }
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/saasus-platform/saasus-sdk-php",
+  "keywords": [
+    "saasus",
+    "auth",
+    "authentication",
+    "openapi",
+    "openapi-generator",
+    "anti-pattern",
+    "php-sdk",
+    "api-client",
+    "laravel",
+    "sdk",
+    "multi-tenant",
+    "saas"
   ],
   "require": {
     "php": ">=8.0.2",


### PR DESCRIPTION
- パッケージ公開用の GitHub Actions ワークフロー（タグ push 時に Packagist に通知）を追加
- composer.json に以下を追加：
  - license / homepage / authors / keywords / support

初回の Packagist 登録は UI から行う必要あり
　→ 登録後はこのワークフローのみで自動通知が可能  
　→ Packagist が自動で追加した GitHub Webhook は残っているが、通知は curl で代替可能なため削除しても問題なし

今後、SDK 用のテストが追加された場合は、Packagist 通知前にテストを実行するようワークフローを修正する可能性あり。
