### PR TITLE
X-SaaSus-Trace-Id 自動引継機能の追加

### DIFF
--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -34,8 +34,9 @@ class Client
     protected string $apibase;
     protected string $referer;
     protected string $xSaasusReferer;
+    protected string $xSaasusTraceId;
 
-    function __construct($referer = "", $xSaasusReferer = "")
+    function __construct($referer = "", $xSaasusReferer = "", $xSaasusTraceId = "")
     {
         $this->secret = getenv('SAASUS_SECRET_KEY');
         $this->saasid = getenv('SAASUS_SAAS_ID');
@@ -59,6 +60,7 @@ class Client
 
         $this->referer = $referer;
         $this->xSaasusReferer = $xSaasusReferer;
+        $this->xSaasusTraceId = $xSaasusTraceId;
 
         $handlers = HandlerStack::create();
         $handlers->push(new GuzzleMiddleware(
@@ -66,7 +68,8 @@ class Client
             $this->saasid,
             $this->apikey,
             $this->referer,
-            $this->xSaasusReferer
+            $this->xSaasusReferer,
+            $this->xSaasusTraceId
         ));
 
         $this->guzzleClient = new GuzzleClient(

--- a/src/Api/GuzzleMiddleware.php
+++ b/src/Api/GuzzleMiddleware.php
@@ -11,14 +11,16 @@ class GuzzleMiddleware
     protected string $apikey;
     protected string $referer;
     protected string $xSaasusReferer;
+    protected string $xSaasusTraceId;
 
-    function __construct($secret = "", $saasid = "", $apikey = "", $referer = "", $xSaasusReferer = "")
+    function __construct($secret = "", $saasid = "", $apikey = "", $referer = "", $xSaasusReferer = "", $xSaasusTraceId = "")
     {
         $this->secret = $secret;
         $this->saasid = $saasid;
         $this->apikey = $apikey;
         $this->referer = $referer;
         $this->xSaasusReferer = $xSaasusReferer;
+        $this->xSaasusTraceId = $xSaasusTraceId;
     }
 
     public function __invoke(callable $next)
@@ -45,6 +47,9 @@ class GuzzleMiddleware
         }
         if (!empty($this->xSaasusReferer)) {
             $req = $req->withHeader('x-saasus-referer', $this->xSaasusReferer);
+        }
+        if (!empty($this->xSaasusTraceId)) {
+            $req = $req->withHeader('X-SaaSus-Trace-Id', $this->xSaasusTraceId);
         }
 
         return call_user_func($this->next, $req, $options);

--- a/src/Laravel/Middleware/Auth.php
+++ b/src/Laravel/Middleware/Auth.php
@@ -46,8 +46,13 @@ class Auth
             $xSaasusReferer = "";
         }
 
+        $xSaasusTraceId = $request->headers->get('x-saasus-trace-id');
+        if (empty($xSaasusTraceId)) {
+            $xSaasusTraceId = "";
+        }
+
         // リクエスト送信
-        $client = new ApiClient($referer, $xSaasusReferer);
+        $client = new ApiClient($referer, $xSaasusReferer, $xSaasusTraceId);
         $authApiClient = $client->getAuthClient();
         try {
             $response = $authApiClient->getUserInfo(['token' => $token], $authApiClient::FETCH_RESPONSE);


### PR DESCRIPTION
## 概要
`X-SaaSus-Trace-Id` ヘッダーの自動引継機能を実装しました。

アプリケーションサーバーが `X-SaaSus-Trace-Id` ヘッダーを含むリクエストを受信した場合、その値が同一リクエストライフサイクル内の後続の SaaSus API 呼び出しに自動的に転送されます。

## 変更内容
- `src/Laravel/Middleware/Auth.php`: 受信リクエストから `X-SaaSus-Trace-Id` を取得し ApiClient に渡す
- `src/Api/Client.php`: `xSaaSusTraceId` を受け取り GuzzleMiddleware に渡す
- `src/Api/GuzzleMiddleware.php`: `xSaaSusTraceId` を受け取り、送信リクエストに `X-SaaSus-Trace-Id` ヘッダーを付与する

## 実装パターン
既存の `X-SaaSus-Referer` の実装と同じパターンに従っています。